### PR TITLE
[Tests] Rename time package and Add TODO to time tests

### DIFF
--- a/constants/time_constants.py
+++ b/constants/time_constants.py
@@ -8,8 +8,8 @@ __all__ = [
 ]
 
 MODIFIED_JULIAN_DATE_OFFSET = 2400000.5
-JD_J2000 = 2451545.0  # Terrestrial time
-DAY_IN_SECONDS = 86400
+JD_J2000 = 2451545.0
+DAY_IN_SECONDS = 86400.0  # Terrestrial time
 kCenturyInJulianDays = 36525
 ATOMIC_TO_TERRESTRIAL_S = 32.184
 kDayInMinutes = 1440


### PR DESCRIPTION
This PR renames the `time` package to `clock` and move all the TODO tasks to the top of the file.